### PR TITLE
Use SVG's viewBox if available

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -11,7 +11,28 @@ module.exports = function rasterize(phantomProcess, svgContent, format, scale, c
 
                         page.content = svg;
                         box = page.evaluate(function () {
-                            return document.querySelector('svg').getBoundingClientRect();
+                            var boundingRect;
+
+                            var svg = document.querySelector('svg');
+                            if (svg.viewBox && svg.viewBox.baseVal) {
+                                var vb = svg.viewBox.baseVal;
+                                vb.x = vb.x || 0;
+                                vb.y = vb.y || 0;
+                                vb.width = vb.width || 0;
+                                vb.height = vb.height || 0;
+                                boundingRect = {
+                                    left: vb.x,
+                                    top: vb.y,
+                                    width: vb.width,
+                                    height: vb.height,
+                                    right: vb.x + vb.width,
+                                    bottom: vb.y + vb.height
+                                };
+                            } else {
+                                boundingRect = svg.getBoundingClientRect();
+                            }
+
+                            return boundingRect;
                         });
 
                         Object.keys(box).forEach(function (key) {


### PR DESCRIPTION
This library is awesome, but it crops the whitespace around the SVG. This patch tries to use the viewbox (.viewBox) if available. The fallback is the existing getBoundingClientRect().