### PR TITLE
Bump phridge to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "through2": "*",
     "gulp-util": "~2.2.14",
-    "phridge": "~0.1.2"
+    "phridge": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.10.0",


### PR DESCRIPTION
When using phridge 0.1 we ran into an issue on Windows (`Cannot start phantomjs: Phantom didn't respond within 30 seconds`). Updating it to the stable version resolves this.
