### PR TITLE
Replace gutil with plugin-error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var through = require('through2'),
-    gutil = require('gulp-util'),
     rasterize = require('./lib/converter'),
-    PluginError = gutil.PluginError,
+    PluginError = require('plugin-error'),
     phridge = require('phridge');
 
 const PLUGIN_NAME = 'gulp-raster';

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "through2": "*"
   },
   "devDependencies": {
-    "mocha": "~1.10.0",
-    "chai": "~1.8.0",
-    "gulp": "~3.8.1",
-    "gulp-mocha": "~0.4.1",
-    "gulp-jshint": "~1.3.4",
-    "jshint-stylish": "~0.1.5",
-    "run-sequence": "^0.3.6"
+    "chai": "~4.1.2",
+    "gulp": "~3.9.1",
+    "gulp-jshint": "~2.1.0",
+    "gulp-mocha": "~5.0.0",
+    "jshint": "^2.9.5",
+    "jshint-stylish": "~2.2.1",
+    "mocha": "~5.0.0",
+    "run-sequence": "^2.2.1"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "gulp-util": "~2.2.14",
     "phridge": "~2.0.0",
+    "plugin-error": "^1.0.1",
     "through2": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
- replaces deprecated `gutil` ([details](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5))
- update `devDependencies`